### PR TITLE
Feature/smart display request handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ gulp.task("clean", function() {
 
 /** Runs all tests. We dont need to emit sourcemaps here since jasmine-ts handles this for us. */
 gulp.task("test", ["build-sources"], shell.task('jasmine-ts "**/*.spec.ts"'));
-gulp.task("test-coverage", ["build-sources"], shell.task('nyc -e .ts -x "*.spec.ts" jasmine-ts "**/*.spec.ts"'));
+gulp.task("test-coverage", ["build-sources"], shell.task('nyc --include "src" --all -e .ts -x "*.spec.ts" jasmine-ts "**/*.spec.ts"'));
 
 /** Watches file changes in source or spec files and executes specs automatically */
 gulp.task("specs-watcher", ["build-sources"], function() {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslint": "^5.4.0",
     "tslint-config-airbnb": "^5.9.2",
     "tslint-config-prettier": "^1.13.0",
-    "typescript": "~2.9.2",
+    "typescript": "^2.9.2",
     "@types/jasmine": "^2.5.48",
     "inversify-components": "^0.4.0",
     "inversify": "4.1.1",

--- a/spec/extractor.spec.ts
+++ b/spec/extractor.spec.ts
@@ -1,4 +1,4 @@
-import {} from "assistant-source";
+import { GenericIntent } from "assistant-source";
 // tslint:disable-next-line:no-submodule-imports
 import { componentInterfaces } from "assistant-source/lib/components/unifier/private-interfaces";
 import { validRequestContext } from "./support/mocks/request-context";
@@ -109,7 +109,7 @@ describe("this.extractor", function() {
       it("returns unhandeld intent", async function() {
         expect(this.extraction).toEqual({
           sessionID: "my-dialogflow-session",
-          intent: 2,
+          intent: GenericIntent.Unhandled,
           entities: { param1: "param-value1", param2: "param-value2" },
           language: "en",
           platform: this.extractor.component.name,

--- a/spec/extractor.spec.ts
+++ b/spec/extractor.spec.ts
@@ -83,19 +83,40 @@ describe("this.extractor", function() {
   });
 
   describe("extract", function() {
-    it("returns correct extraction", async function(done) {
-      this.extraction = await this.extractor.extract(this.context);
+    describe("with valid request", function() {
+      it("returns correct extraction", async function(done) {
+        this.extraction = await this.extractor.extract(this.context);
 
-      expect(this.extraction).toEqual({
-        sessionID: "my-dialogflow-session",
-        intent: "Matched Intent Name",
-        entities: { param1: "param-value1", param2: "param-value2" },
-        language: "en",
-        platform: this.extractor.component.name,
-        spokenText: "user's original agent query",
-        additionalParameters: { key1: "value1" },
+        expect(this.extraction).toEqual({
+          sessionID: "my-dialogflow-session",
+          intent: "Matched Intent Name",
+          entities: { param1: "param-value1", param2: "param-value2" },
+          language: "en",
+          platform: this.extractor.component.name,
+          spokenText: "user's original agent query",
+          additionalParameters: { key1: "value1" },
+        });
+        done();
       });
-      done();
+    });
+
+    describe("with unhandled intent", function() {
+      beforeEach(async function() {
+        this.context.body.queryResult.intent.displayName = "__unhandled";
+        this.extraction = await this.extractor.extract(this.context);
+      });
+
+      it("returns unhandeld intent", async function() {
+        expect(this.extraction).toEqual({
+          sessionID: "my-dialogflow-session",
+          intent: 2,
+          entities: { param1: "param-value1", param2: "param-value2" },
+          language: "en",
+          platform: this.extractor.component.name,
+          spokenText: "user's original agent query",
+          additionalParameters: { key1: "value1" },
+        });
+      });
     });
   });
 });

--- a/src/components/apiai/extractor.ts
+++ b/src/components/apiai/extractor.ts
@@ -84,7 +84,8 @@ export class Extractor implements RequestExtractor {
     if (
       typeof context.body.queryResult === "undefined" ||
       typeof context.body.queryResult.intent === "undefined" ||
-      typeof context.body.queryResult.intent.displayName !== "string"
+      typeof context.body.queryResult.intent.displayName !== "string" ||
+      context.body.queryResult.intent.displayName === "__unhandled"
     ) {
       return GenericIntent.Unhandled;
     }


### PR DESCRIPTION
- show all files from src folder only in test-coverage
- extraction of Intent with name "__unhandled" as UnhandledGenericIntent, instead of using fallback feature in assistant-source