### PR TITLE
fixes generator for custom entities

### DIFF
--- a/src/components/apiai/builder.ts
+++ b/src/components/apiai/builder.ts
@@ -80,7 +80,7 @@ export class Builder implements PlatformGenerator.Extension {
     const config = this.component.configuration;
 
     return Object.keys(customEntityMapping).map(type => {
-      if (typeof config.entities[type] === "undefined") {
+      if (typeof config.entities[type] !== "undefined") {
         const entity = {
           id: uuid(),
           name: type,


### PR DESCRIPTION
I noticed this bug while i was trying to generate custom entities for apiai in my AssistantJS application. 
I just fixed this typo. Now this works as intended.